### PR TITLE
Bump license year to 2024

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2023 CERN (home.cern)
+SPDX-FileCopyrightText: 2024 CERN (home.cern)
 
 SPDX-License-Identifier: CC-BY-SA-4.0+
 -->

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2023 CERN (home.cern)
+SPDX-FileCopyrightText: 2024 CERN (home.cern)
 
 SPDX-License-Identifier: CC-BY-SA-4.0+
 -->

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2023 CERN (home.cern)
+# SPDX-FileCopyrightText: 2024 CERN (home.cern)
 #
 # SPDX-License-Identifier: CC-BY-SA-4.0+
 

--- a/.github/ISSUE_TEMPLATE/content.md
+++ b/.github/ISSUE_TEMPLATE/content.md
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2023 CERN (home.cern)
+# SPDX-FileCopyrightText: 2024 CERN (home.cern)
 #
 # SPDX-License-Identifier: CC-BY-SA-4.0+
 

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2023 CERN (home.cern)
+# SPDX-FileCopyrightText: 2024 CERN (home.cern)
 #
 # SPDX-License-Identifier: CC-BY-SA-4.0+
 

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2023 CERN (home.cern)
+# SPDX-FileCopyrightText: 2024 CERN (home.cern)
 #
 # SPDX-License-Identifier: CC-BY-SA-4.0+
 

--- a/.github/ISSUE_TEMPLATE/layout.md
+++ b/.github/ISSUE_TEMPLATE/layout.md
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2023 CERN (home.cern)
+# SPDX-FileCopyrightText: 2024 CERN (home.cern)
 #
 # SPDX-License-Identifier: CC-BY-SA-4.0+
 

--- a/.github/ISSUE_TEMPLATE/project.md
+++ b/.github/ISSUE_TEMPLATE/project.md
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2023 CERN (home.cern)
+# SPDX-FileCopyrightText: 2024 CERN (home.cern)
 #
 # SPDX-License-Identifier: CC-BY-SA-4.0+
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2023 CERN (home.cern)
+# SPDX-FileCopyrightText: 2024 CERN (home.cern)
 #
 # SPDX-License-Identifier: CC-BY-SA-4.0+
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2023 CERN (home.cern)
+SPDX-FileCopyrightText: 2024 CERN (home.cern)
 
 SPDX-License-Identifier: CC-BY-SA-4.0+
 -->

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2023 CERN (home.cern)
+SPDX-FileCopyrightText: 2024 CERN (home.cern)
 
 SPDX-License-Identifier: CC-BY-SA-4.0+
 -->

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2023 CERN (home.cern)
+# SPDX-FileCopyrightText: 2024 CERN (home.cern)
 #
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2023 CERN (home.cern)
+# SPDX-FileCopyrightText: 2024 CERN (home.cern)
 #
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2023 CERN (home.cern)
+# SPDX-FileCopyrightText: 2024 CERN (home.cern)
 #
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/.github/workflows/makefile.yaml
+++ b/.github/workflows/makefile.yaml
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2023 CERN (home.cern)
+# SPDX-FileCopyrightText: 2024 CERN (home.cern)
 #
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2023 CERN (home.cern)
+# SPDX-FileCopyrightText: 2024 CERN (home.cern)
 #
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2023 CERN (home.cern)
+# SPDX-FileCopyrightText: 2024 CERN (home.cern)
 #
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2023 CERN (home.cern)
+# SPDX-FileCopyrightText: 2024 CERN (home.cern)
 #
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/.github/workflows/yaml.yaml
+++ b/.github/workflows/yaml.yaml
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2023 CERN (home.cern)
+# SPDX-FileCopyrightText: 2024 CERN (home.cern)
 #
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 CERN (home.cern)
+# SPDX-FileCopyrightText: 2024 CERN (home.cern)
 #
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -4,5 +4,5 @@ Upstream-Contact: CERN (home.cern)
 Source: https://github.com/OHWR/ohwr.org
 
 Files: src/hugo/go.sum
-Copyright: 2023 CERN (home.cern)
+Copyright: 2024 CERN (home.cern)
 License: BSD-3-Clause

--- a/LICENSES/BSD-3-Clause.txt
+++ b/LICENSES/BSD-3-Clause.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2023 CERN (home.cern). 
+Copyright (c) 2024 CERN (home.cern). 
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 CERN (home.cern)
+# SPDX-FileCopyrightText: 2024 CERN (home.cern)
 #
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2023 CERN (home.cern)
+SPDX-FileCopyrightText: 2024 CERN (home.cern)
 
 SPDX-License-Identifier: CC-BY-SA-4.0+
 -->

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2023 CERN (home.cern)
+# SPDX-FileCopyrightText: 2024 CERN (home.cern)
 #
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 CERN (home.cern)
+# SPDX-FileCopyrightText: 2024 CERN (home.cern)
 #
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/src/compose/__main__.py
+++ b/src/compose/__main__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 CERN (home.cern)
+# SPDX-FileCopyrightText: 2024 CERN (home.cern)
 #
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/src/compose/config.py
+++ b/src/compose/config.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 CERN (home.cern)
+# SPDX-FileCopyrightText: 2024 CERN (home.cern)
 #
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/src/compose/sources.py
+++ b/src/compose/sources.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 CERN (home.cern)
+# SPDX-FileCopyrightText: 2024 CERN (home.cern)
 #
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/src/compose/url.py
+++ b/src/compose/url.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 CERN (home.cern)
+# SPDX-FileCopyrightText: 2024 CERN (home.cern)
 #
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/src/hugo/archetypes/news.md
+++ b/src/hugo/archetypes/news.md
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2023 CERN (home.cern)
+# SPDX-FileCopyrightText: 2024 CERN (home.cern)
 #
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/src/hugo/archetypes/projects.md
+++ b/src/hugo/archetypes/projects.md
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2023 CERN (home.cern)
+# SPDX-FileCopyrightText: 2024 CERN (home.cern)
 #
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/src/hugo/assets/scss/_custom.scss
+++ b/src/hugo/assets/scss/_custom.scss
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 CERN (home.cern)
+// SPDX-FileCopyrightText: 2024 CERN (home.cern)
 //
 // SPDX-License-Identifier: BSD-3-Clause
 

--- a/src/hugo/config.yaml
+++ b/src/hugo/config.yaml
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2023 CERN (home.cern)
+# SPDX-FileCopyrightText: 2024 CERN (home.cern)
 #
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/src/hugo/content/_index.md
+++ b/src/hugo/content/_index.md
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2023 CERN (home.cern)
+# SPDX-FileCopyrightText: 2024 CERN (home.cern)
 #
 # SPDX-License-Identifier: CC-BY-SA-4.0+
 

--- a/src/hugo/content/about/index.md
+++ b/src/hugo/content/about/index.md
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2023 CERN (home.cern)
+# SPDX-FileCopyrightText: 2024 CERN (home.cern)
 #
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/src/hugo/content/licenses/index.md
+++ b/src/hugo/content/licenses/index.md
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2023 CERN (home.cern)
+# SPDX-FileCopyrightText: 2024 CERN (home.cern)
 #
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/src/hugo/content/submit-project/index.md
+++ b/src/hugo/content/submit-project/index.md
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2023 CERN (home.cern)
+# SPDX-FileCopyrightText: 2024 CERN (home.cern)
 #
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/src/hugo/content/topics/_index.md
+++ b/src/hugo/content/topics/_index.md
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: 2023 CERN (home.cern)
+# SPDX-FileCopyrightText: 2024 CERN (home.cern)
 #
 # SPDX-License-Identifier: BSD-3-Clause
 

--- a/src/hugo/go.mod
+++ b/src/hugo/go.mod
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2023 CERN (home.cern)
+// SPDX-FileCopyrightText: 2024 CERN (home.cern)
 //
 // SPDX-License-Identifier: BSD-3-Clause
 

--- a/src/hugo/layouts/_default/list.html
+++ b/src/hugo/layouts/_default/list.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 
 <!--
-SPDX-FileCopyrightText: 2023 CERN (home.cern)
+SPDX-FileCopyrightText: 2024 CERN (home.cern)
 
 SPDX-License-Identifier: BSD-3-Clause
 -->

--- a/src/hugo/layouts/_default/single.html
+++ b/src/hugo/layouts/_default/single.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 
 <!--
-SPDX-FileCopyrightText: 2023 CERN (home.cern)
+SPDX-FileCopyrightText: 2024 CERN (home.cern)
 
 SPDX-License-Identifier: BSD-3-Clause
 -->

--- a/src/hugo/layouts/index.html
+++ b/src/hugo/layouts/index.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 
 <!--
-SPDX-FileCopyrightText: 2023 CERN (home.cern)
+SPDX-FileCopyrightText: 2024 CERN (home.cern)
 
 SPDX-License-Identifier: BSD-3-Clause
 -->

--- a/src/hugo/layouts/news/list.html
+++ b/src/hugo/layouts/news/list.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
 
 <!--
-SPDX-FileCopyrightText: 2023 CERN (home.cern)
+SPDX-FileCopyrightText: 2024 CERN (home.cern)
 
 SPDX-License-Identifier: BSD-3-Clause
 -->

--- a/src/hugo/layouts/partials/featured.html
+++ b/src/hugo/layouts/partials/featured.html
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2023 CERN (home.cern)
+SPDX-FileCopyrightText: 2024 CERN (home.cern)
 
 SPDX-License-Identifier: BSD-3-Clause
 -->

--- a/src/hugo/layouts/partials/horizontal-card.html
+++ b/src/hugo/layouts/partials/horizontal-card.html
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2023 CERN (home.cern)
+SPDX-FileCopyrightText: 2024 CERN (home.cern)
 
 SPDX-License-Identifier: BSD-3-Clause
 -->

--- a/src/hugo/layouts/partials/vertical-card.html
+++ b/src/hugo/layouts/partials/vertical-card.html
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2023 CERN (home.cern)
+SPDX-FileCopyrightText: 2024 CERN (home.cern)
 
 SPDX-License-Identifier: BSD-3-Clause
 -->

--- a/src/hugo/layouts/shortcodes/button.html
+++ b/src/hugo/layouts/shortcodes/button.html
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2023 CERN (home.cern)
+SPDX-FileCopyrightText: 2024 CERN (home.cern)
 
 SPDX-License-Identifier: BSD-3-Clause
 -->

--- a/src/hugo/layouts/shortcodes/latest-news.html
+++ b/src/hugo/layouts/shortcodes/latest-news.html
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2023 CERN (home.cern)
+SPDX-FileCopyrightText: 2024 CERN (home.cern)
 
 SPDX-License-Identifier: BSD-3-Clause
 -->

--- a/src/hugo/layouts/shortcodes/project.html
+++ b/src/hugo/layouts/shortcodes/project.html
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2023 CERN (home.cern)
+SPDX-FileCopyrightText: 2024 CERN (home.cern)
 
 SPDX-License-Identifier: BSD-3-Clause
 -->


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2023 CERN (home.cern)

SPDX-License-Identifier: CC-BY-SA-4.0+
-->

Closes #101  <!-- markdownlint-disable-line MD041 -->

## Description 📄

The license headers were dated 2023 but it's 2024 so they should be update.
Also the license year in reuse  `.reuse/dep5` should be update along with the licenses under the `LICENSES` directory.
