### PR TITLE
Remove unreachable footer links

### DIFF
--- a/src/hugo/config.yaml
+++ b/src/hugo/config.yaml
@@ -62,22 +62,16 @@ menus:
       url: 'about/'
     - name: 'Projects'
       url: 'projects/'
-    - name: 'Submit Project'
-      url: 'submit-project/'
   footer_middle:
     - name: 'Licenses'
       url: 'licenses/'
-    - name: 'Members'
-      url: 'members/'
-    - name: 'Help'
-      url: 'help/'
-  footer_right:
     - name: 'Forum'
       url: 'https://forums.ohwr.org/'
-    - name: 'FAQ'
-      url: 'faq/'
+  footer_right:
     - name: 'News'
       url: 'news/'
+    - name: 'Submit Project'
+      url: 'submit-project/'
 params:
   favicon: 'https://be-cem-edl.web.cern.ch/ohwr/graphics/favicon.ico'
   logo: 'https://be-cem-edl.web.cern.ch/ohwr/graphics/logo.png'


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2024 CERN (home.cern)

SPDX-License-Identifier: CC-BY-SA-4.0+
-->

Closes #89  <!-- markdownlint-disable-line MD041 -->

## Description 📄

The following footer links were unreachable and therefore were removed:
* Help
* Members
* FAQ
