### PR TITLE
Remove Tags section

### DIFF
--- a/src/compose/config.py
+++ b/src/compose/config.py
@@ -82,7 +82,6 @@ class ProjConfig(BaseModel, extra='forbid'):
     forum: Optional[URL] = None
     links: Optional[list[LinkConfig]] = None
     categories: Optional[list[str]] = None
-    tags: Optional[list[str]] = None
     news: Optional[list[NewsConfig]] = None
 
     def __init__(self, licenses: list[str], spdx_license_list: dict, **kwargs):

--- a/src/hugo/archetypes/projects.md
+++ b/src/hugo/archetypes/projects.md
@@ -16,12 +16,6 @@ images:
 {{ with .featured }}
 featured: {{ . }}
 {{ end }}
-{{ with .tags }}
-tags:
-{{ range . }}
-  - {{ . }}
-{{ end }}
-{{ end }}
 {{ with .categories }}
 categories:
 {{ range . }}

--- a/src/hugo/config.yaml
+++ b/src/hugo/config.yaml
@@ -17,7 +17,6 @@ markup:
     style: 'native'
 taxonomies:
   category: 'categories'
-  tag: 'tags'
   topic: 'topics'
 module:
   imports:
@@ -28,34 +27,26 @@ menus:
       url: 'about/'
       weight: 1
     - name: 'Projects'
-      weight: 2
-    - name: 'All Projects'
       url: 'projects/'
-      weight: 3
-      parent: 'Projects'
+      weight: 2
     - name: 'Categories'
       url: 'categories/'
-      weight: 4
-      parent: 'Projects'
-    - name: 'Tags'
-      url: 'tags/'
-      weight: 5
-      parent: 'Projects'
+      weight: 3
     - name: 'Licenses'
       url: 'licenses/'
-      weight: 6
+      weight: 4
     - name: 'Forum'
       url: 'https://forums.ohwr.org/'
-      weight: 7
+      weight: 5
     - name: 'News'
-      weight: 8
+      weight: 6
     - name: 'All News'
       url: 'news/'
-      weight: 9
+      weight: 7
       parent: 'News'
     - name: 'Topics'
       url: 'topics/'
-      weight: 10
+      weight: 8
       parent: 'News'
   footer_left:
     - name: 'About'

--- a/src/hugo/content/submit-project/index.md
+++ b/src/hugo/content/submit-project/index.md
@@ -66,8 +66,6 @@ project:
       url: 'https://foo.com/bar2'
   # (optional) Categories to which your project belongs (e.g. 'FMC Carriers').
   categories: ['Category X', 'Category Y', 'Category Z']
-  # (optional) Tags that characterize your project (e.g. 'ethernet').
-  tags: ['Tag1', 'Tag2', 'Tag3']
 ```
 
 ### Step 2: Create an issue


### PR DESCRIPTION
Closes #85

## Description 📄

Remove the "Tags" section in favor of the "Categories" section.

## Additional Notes 📝

The `tags` field in the `.ohwr.yaml` file has been removed.
The `tags` field in the project page has been removed.
The `.ohwr.yaml` template in the "Submit Project" page has been update.
"Tags" was removed from the "Projects" dropdown menu in the navbar.
The navbar was updated - "Projects" points to the "Projects" section and "Categories" was added next to "Projects"