### PR TITLE
Schedule daily deployment to GitHub Pages to 8AM and 3PM UTC

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,6 +6,8 @@
 name: Deploy to GitHub Pages
 
 on:  # yamllint disable-line rule:truthy
+  schedule:
+    - cron: '0 8,15 * * *'
   push:
     branches:
       - master


### PR DESCRIPTION
Closes #102

## Description 📄

Schedules the `deploy` GitHub Actions job to run every day at 8AM and 3PM UTC.
The `deploy` job will  run the `build` job to build the page from scratch before deploying to GitHub Pages.
The page content will therefore be updated automatically 2 times a day, reflecting changes maintainers do on their projects.

## Additional Notes 📝

8AM and 3PM UTC correspond to 9AM and 4PM CET.
GitHub Actions job scheduling is documented here: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule
