### PR TITLE
Add Contact section to project pages

### DIFF
--- a/.github/ISSUE_TEMPLATE/project.md
+++ b/.github/ISSUE_TEMPLATE/project.md
@@ -14,7 +14,7 @@ assignees: vascoguita
 
 - **Git Repository URL:** <https://example.com/your-username/your-project.git>
 
-## Owner 👤
+## Maintainer 👤
 
 - **Name:** Your Name
 - **Email:** <your.email@example.com>

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: pip install pydantic PyYAML -c requirements.txt
+        run: pip install pydantic PyYAML email_validator -c requirements.txt
       - name: Build
         run: make build
         env:

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ lint-python:
 
 .PHONY: lint-markdown
 lint-markdown:
-	markdownlint-cli2 ${CURDIR}/**/*.md -c
+	markdownlint-cli2 '${CURDIR}/**/*.md' '#${CURDIR}/.venv'
 
 ###############################################################################
 # Clean

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ theme.
 * [Python](https://www.python.org/downloads) >= 3.11.4
 * [PyYAML](https://pyyaml.org/wiki/PyYAMLDocumentation) >= 6.0.1
 * [Pydantic](https://docs.pydantic.dev/latest/install) >= 2.6.4
+* [email-validator](https://github.com/JoshData/python-email-validator?tab=readme-ov-file#installation)
+  \>= 2.1.1
 
 ### Steps :footprints:
 

--- a/config.yaml
+++ b/config.yaml
@@ -21,14 +21,30 @@ projects:
     # URL to the Git repository of the project.
     # The Git repository must contain a .ohwr.yaml file.
     url: 'https://github.com/vascoguita/svec.git'
+    # Project maintainer contact
+    contact:
+      name: 'Vasco Guita'
+      email: 'vasco.guita@cern.ch'
     # (optional) Show project as featured.
     featured: true
   - id: 'spec'
     url: 'https://github.com/vascoguita/spec.git'
     featured: true
+    contact:
+      name: 'Vasco Guita'
+      email: 'vasco.guita@cern.ch'
   - id: 'fmc-tdc'
     url: 'https://github.com/vascoguita/fmc-tdc.git'
+    contact:
+      name: 'Vasco Guita'
+      email: 'vasco.guita@cern.ch'
   - id: 'fmc-delay-1ns-8cha'
     url: 'https://github.com/vascoguita/fmc-delay-1ns-8cha.git'
+    contact:
+      name: 'Vasco Guita'
+      email: 'vasco.guita@cern.ch'
   - id: 'fmc-adc-100m14b4cha'
     url: 'https://github.com/vascoguita/fmc-adc-100m14b4cha.git'
+    contact:
+      name: 'Vasco Guita'
+      email: 'vasco.guita@cern.ch'

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@
 
 pydantic==2.6.4
 PyYAML==6.0.1
+email_validator==2.1.1
 reuse==3.0.1
 wemake-python-styleguide==0.18.0
 yamllint==1.35.1

--- a/src/compose/config.py
+++ b/src/compose/config.py
@@ -15,7 +15,7 @@ from urllib.error import URLError
 from urllib.parse import urlparse
 
 import yaml
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, EmailStr, Field, ValidationError
 from url import URL
 
 
@@ -23,7 +23,18 @@ class ConfigError(Exception):
     """Failed to load, parse or validate configuration."""
 
 
-class LinkConfig(BaseModel, extra='forbid'):
+class BaseModelForbidExtra(BaseModel, extra='forbid'):
+    """Custom base class for Pydantic models with extra='forbid'."""
+
+
+class ContactConfig(BaseModelForbidExtra):
+    """Parses and validates contact configuration."""
+
+    name: str
+    email: EmailStr
+
+
+class LinkConfig(BaseModelForbidExtra):
     """Parses and validates link configuration."""
 
     name: str
@@ -55,7 +66,7 @@ class LicenseConfig(LinkConfig):
         raise ConfigError(msg.format(license_id))
 
 
-class NewsConfig(BaseModel, extra='forbid'):
+class NewsConfig(BaseModelForbidExtra):
     """Parses and validates news configuration."""
 
     title: str
@@ -65,11 +76,12 @@ class NewsConfig(BaseModel, extra='forbid'):
     content: Optional[str] = None  # noqa: WPS110
 
 
-class ProjConfig(BaseModel, extra='forbid'):
+class ProjConfig(BaseModelForbidExtra):
     """Loads, parses and validates project sources configuration."""
 
     id: str
     url: str
+    contact: ContactConfig
     featured: Optional[bool] = False
     name: str
     description: str

--- a/src/hugo/content/submit-project/index.md
+++ b/src/hugo/content/submit-project/index.md
@@ -73,7 +73,7 @@ project:
 Open an issue on the OHWR GitHub repository specifying:
 
 * The URL of the project's git repository.
-* The name and email address of the responsible for the project.
+* The name and email address of the project maintainer.
 
 Our team will review your submission, and if everything is in order, your
 project will be added to the Open Hardware Repository.

--- a/src/hugo/layouts/shortcodes/project.html
+++ b/src/hugo/layouts/shortcodes/project.html
@@ -54,6 +54,10 @@ SPDX-License-Identifier: BSD-3-Clause
       {{ end }}
     </ul>
     {{ end }}
+    {{ with .contact }}
+    <h3 class="section-title">Contact</h3>
+    <pt><a href="mailto:{{ .email }}">{{ .name }}</a></p>
+    {{ end }}
     {{ with .licenses }}
     <h3 class="section-title">Licenses</h3>
     <ul class="fa-ul mb-0">


### PR DESCRIPTION
Closes #92

## Description 📄

* Add 'Contact' section to the project pages.
* Introduce an obligatory `contact` field to each project in the `config.yaml` file that accepts a name and an email address.
* Project maintainers provide the contact in the project submission issue.