### PR TITLE
70 parse news from a markdown file

### DIFF
--- a/src/compose/newsfeed.py
+++ b/src/compose/newsfeed.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: 2024 CERN (home.cern)
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Load, parse and validate newsfeed."""
+
+import datetime
+import re
+from typing import Optional
+from urllib import request
+from urllib.error import URLError
+
+from base import URL, BaseModelForbidExtra
+from pydantic import ValidationError
+
+
+class NewsfeedError(Exception):
+    """Failed to load, parse or validate newsfeed."""
+
+
+class News(BaseModelForbidExtra):
+    """Parses and validates news."""
+
+    title: str
+    date: datetime.date
+    images: Optional[list[URL]] = None
+    topics: Optional[list[str]] = None
+    content: Optional[str] = None  # noqa: WPS110
+
+    @classmethod
+    def load(cls, md: str):  # noqa: WPS210
+        """
+        Parse and validate Markdown news.
+
+        Parameters:
+            md: Markdown news.
+
+        Returns:
+            News object.
+
+        Raises:
+            NewsfeedError: if parsing or validating the news fails.
+        """
+        try:
+            title, after_title = md.split('\n', 1)
+        except ValueError as title_error:
+            msg = 'Failed to fetch title from news item:\n↳ {0}'
+            raise NewsfeedError(msg.format(title_error))
+
+        try:
+            date, after_date = after_title.strip().split('\n', 1)
+        except ValueError as date_error:
+            msg = 'Failed to fetch date from news item:\n↳ {0}'
+            raise NewsfeedError(msg.format(date_error))
+        date = datetime.date.fromisoformat(date)
+
+        image_pattern = r'!\[.*?\]\((.*?)\)'
+        images = re.findall(image_pattern, after_date)
+        content = re.sub(image_pattern, '', after_date).strip()  # noqa: WPS110
+
+        try:
+            return cls(title=title, date=date, images=images, content=content)
+        except ValidationError as news_error:
+            msg = 'News is not valid:\n↳ {0}'
+            raise NewsfeedError(msg.format(news_error))
+
+
+class Newsfeed(BaseModelForbidExtra):
+    """Loads, parses and validates newsfeed."""
+
+    news: Optional[list[News]] = None
+
+    @classmethod
+    def from_url(cls, url: str):
+        """
+        Load a Markdown newsfeed from a URL.
+
+        Parameters:
+            url: Markdown newsfeed URL.
+
+        Returns:
+            Newsfeed object.
+
+        Raises:
+            NewsfeedError: if loading the newsfeed fails.
+        """
+        try:
+            with request.urlopen(url) as response:  # noqa: S310
+                return cls.load(response.read().decode('utf-8'))
+        except URLError as error:
+            msg = 'Failed to request {0}:\n↳ {1}'
+            raise NewsfeedError(msg.format(url, error))
+
+    @classmethod
+    def load(cls, md: str):  # noqa: WPS210
+        """
+        Parse and validate Markdown newsfeed.
+
+        Parameters:
+            md: Markdown newsfeed.
+
+        Returns:
+            Newsfeed object.
+
+        Raises:
+            NewsfeedError: if parsing or validating the newsfeed fails.
+        """
+        try:
+            md = re.sub('<!--(.*?)-->', '', md, flags=re.DOTALL).strip()
+        except ValueError as re_error:
+            msg = 'Failed to process Markdown content:\n↳ {0}'
+            raise NewsfeedError(msg.format(re_error))
+
+        news_list = []
+        news_items = md.split('## ')[1:]
+        for news_item in news_items:
+            news = News.load(news_item)
+            news_list.append(news)
+
+        try:
+            return cls(news=news_list)
+        except ValidationError as validation_error:
+            msg = 'Newsfeed is not valid:\n↳ {0}'
+            raise NewsfeedError(msg.format(validation_error))

--- a/src/compose/sources.py
+++ b/src/compose/sources.py
@@ -10,7 +10,8 @@ from dataclasses import dataclass, field
 from logging import info
 
 import yaml
-from config import CatConfig, NewsConfig, ProjConfig
+from config import CatConfig, ProjConfig
+from newsfeed import News
 
 
 @dataclass
@@ -60,7 +61,7 @@ class ProjSources(Sources):
         """
         sources = []
         for index, news in enumerate(config.news):
-            news.topics.append(config.name)
+            news.topics = [config.name]
             sources.append(
                 NewsSources.from_config(
                     news,
@@ -79,7 +80,7 @@ class NewsSources(Sources):
     """Writes Hugo data and content file for a news page."""
 
     @classmethod
-    def from_config(cls, config: NewsConfig, news_id: str):
+    def from_config(cls, config: News, news_id: str):
         """
         Construct a NewsSources object from the configuration.
 

--- a/src/hugo/archetypes/news.md
+++ b/src/hugo/archetypes/news.md
@@ -11,7 +11,10 @@ title: {{ . }}
 date: {{ . }}
 {{ end }}
 {{ with .images }}
-images: {{ . }}
+images:
+{{ range . }}
+  - {{ . }}
+{{ end }}
 {{ end }}
 {{ with .topics }}
 topics:

--- a/src/hugo/config.yaml
+++ b/src/hugo/config.yaml
@@ -39,15 +39,8 @@ menus:
       url: 'https://forums.ohwr.org/'
       weight: 5
     - name: 'News'
-      weight: 6
-    - name: 'All News'
       url: 'news/'
-      weight: 7
-      parent: 'News'
-    - name: 'Topics'
-      url: 'topics/'
-      weight: 8
-      parent: 'News'
+      weight: 6
   footer_left:
     - name: 'About'
       url: 'about/'

--- a/src/hugo/content/submit-project/index.md
+++ b/src/hugo/content/submit-project/index.md
@@ -7,9 +7,9 @@ title: Submit a Project to OHWR
 ---
 
 Thank you for your interest in submitting your project to the Open Hardware
-Repository. It takes only two steps to submit your project.
+Repository. Please follow the steps bellow to submit your project.
 
-### Step 1: Configure your OHWR project page
+### Configure your OHWR project page
 
 Add an `.ohwr.yaml` file to the root directory of your project's repository.
 This file should follow the following schema:
@@ -21,7 +21,7 @@ version: '1.0.0'
 project:
   # The name of your project.
   name: 'Project Name'
-  # Link to the Markdown file with the description of your project. The
+  # Link to the Markdown description of your project. The
   # description is read from the first section of the file.
   description: 'https://raw.githubusercontent.com/wiki/user/project/Home.md'
   # The website of your project. Use the web page of your git repository if
@@ -42,18 +42,8 @@ project:
   latest_release: 'https://github.com/user/project/releases/latest'
   # (optional) Link to the forum where your community has conversations.
   forum: 'https://forums.ohwr.org/c/project'
-  # (optional) News feed of your project.
-  news:
-    - title: 'News title here'
-      date: 2020-07-30
-      # (optional) Images of the news.
-      images:
-        - 'https://your.news.com/img1.png'
-        - 'https://your.news.com/img2.png'
-      # (optional) The Markdown content of the news.
-      content: 'Quisque sollicitudin velit ac [luctus](https://foo.com/bar).'
-    - title: 'News title here'
-      date: 2018-01-11
+  # (optional) Link to the Markdown newsfeed of your project.
+  newsfeed: 'https://raw.githubusercontent.com/wiki/user/project/news.md'
   # (optional) Addtional links.
   links:
     - name: 'Link text here'
@@ -62,7 +52,51 @@ project:
       url: 'https://foo.com/bar2'
 ```
 
-### Step 2: Create an issue
+### Write a newsfeed (**optional**)
+
+To post news about your project, create a Markdown file (e.g. a `News.md` file
+in the Wiki of your project) and fill in the `newsfeed` field of your
+`.ohwr.yaml` file with the link to your Markdown file.
+
+For each news:
+
+  1. Write the title in a heading level 2: `## News Title`.
+  2. Add the date using the following format: `YYYY-MM-DD`.
+  3. (**optional**) Include image(s) using the following syntax:
+     `![Image Description](Image URL)`.
+  4. Write the content of the news.
+
+Here is an example of a Markdown newsfeed file:
+
+```markdown
+## Important Update on Website
+
+2024-04-03
+
+![Homepage Screenshot](https://example.com/homepage.png)
+![New Feature Preview](https://example.com/feature.png)
+
+This is the content of the first news item. It can contain any relevant
+information or updates.
+
+## Special Event Coming Up!
+
+2024-04-02
+
+![Event Poster](https://example.com/event.png)
+
+This is the content of the second news item. It can contain any relevant
+information or updates.
+
+## Meet Our Team
+
+2024-04-01
+
+This is the content of the third news item. It can contain any relevant
+information or updates.
+```
+
+### Create an issue
 
 Open an issue on the OHWR GitHub repository specifying:
 

--- a/src/hugo/layouts/partials/horizontal-card.html
+++ b/src/hugo/layouts/partials/horizontal-card.html
@@ -10,7 +10,7 @@ SPDX-License-Identifier: BSD-3-Clause
     <div class="col-md-3">
       <img src="{{ index .Params.images 0 | relURL }}" class="m-3 w-100 mh-100 rounded">
     </div>
-    <div class="col-md-9 p-0">
+    <div class="col-md-9 p-0 position-static">
   {{ end }}
       <div class="card-body">
         {{ with .Params.topics }}


### PR DESCRIPTION
Closes #70 

## Description 📄

* Replace the news field in `.ohwr.yaml` with the `newsfeed` field.
* The `newsfeed` field accepts a URL to a markdown file to parse the news from.

## Additional Notes 📝

* Removed "Topics" page from main menu.
* (TODO) Refactoring. This should be done when adding pytest tests.