### PR TITLE
Add compatibility relationships between projects.

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -22,6 +22,10 @@ projects:
     featured: true
     categories:
       - 'FMC Carriers'
+    compatibles:
+      - 'fmc-tdc'
+      - 'fmc-delay-1ns-8cha'
+      - 'fmc-adc-100m14b4cha'
   - id: 'spec'
     repository: 'https://github.com/vascoguita/spec.git'
     contact:
@@ -30,6 +34,10 @@ projects:
     featured: true
     categories:
       - 'FMC Carriers'
+    compatibles:
+      - 'fmc-tdc'
+      - 'fmc-delay-1ns-8cha'
+      - 'fmc-adc-100m14b4cha'
   - id: 'fmc-tdc'
     repository: 'https://github.com/vascoguita/fmc-tdc.git'
     contact:

--- a/src/hugo/config.yaml
+++ b/src/hugo/config.yaml
@@ -19,6 +19,7 @@ taxonomies:
   category: 'categories'
   newsfeed: 'newsfeeds'
   parent: 'parents'
+  compatible: 'compatibles'
 module:
   imports:
     - path: 'github.com/OHWR/bigspring-light-hugo'

--- a/src/hugo/content/submit-project/index.md
+++ b/src/hugo/content/submit-project/index.md
@@ -100,8 +100,9 @@ Open an issue on the OHWR GitHub repository specifying:
 
 * The URL of the project's git repository.
 * The name and email address of the project maintainer.
-* The categories to include the project in (optional).
-* The parent projects (optional).
+* A list of categories to include your project in (optional).
+* A list of parent projects (optional).
+* A list of projects your project is compatible with (optional).
 
 You can choose categories from the [Categories]({{< ref "categories.md" >}})
 page or propose new ones.

--- a/src/hugo/layouts/shortcodes/project.html
+++ b/src/hugo/layouts/shortcodes/project.html
@@ -15,6 +15,7 @@ SPDX-License-Identifier: BSD-3-Clause
 {{ $licenses := .Page.Params.licenses }}
 {{ $parents := where .Site.RegularPages "Params.id" "in" .Page.Params.parents }}
 {{ $children := (.Site.Taxonomies.parents.Get .Page.Params.id).Pages }}
+{{ $compatibles := union (.Site.Taxonomies.compatibles.Get .Page.Params.id).Pages (where .Site.RegularPages "Params.id" "in" .Page.Params.compatibles) }}
 
 <div class="card border-0 shadow-lg">
   <div class="card-body mb-0">
@@ -78,7 +79,7 @@ SPDX-License-Identifier: BSD-3-Clause
   </div>
 </div>
 
-{{ range slice (group "Parent" $parents) (group "Child" $children) }}
+{{ range slice (group "Parent" $parents) (group "Child" $children) (group "Compatible" $compatibles) }}
 {{ if .Pages }}
 <h3 class="text-center">{{ .Key }} Projects</h3>
 <div class="cards-section">


### PR DESCRIPTION
Closes #88 

## Description 📄

1. Introduce  an optional `compatibles` field to each project in the `config.yaml` file that accepts a list of project ids of compatible projects.
2. The projects are listed in horizontal cards under the 'Compatible Projects' section of the project pages.
3. Only one project needs to claim to be compatible with another and compatibility is displayed in both project pages.
4. The 'Submit a Project to OHWR' page instructs project maintainers to specify compatible projects in the project submission issue.