### PR TITLE
Order search bar results

### DIFF
--- a/src/hugo/config.yaml
+++ b/src/hugo/config.yaml
@@ -75,3 +75,7 @@ params:
     link: 'submit-project/'
   search:
     primary_color: '#fd810d'
+    include_sections:
+      - projects
+      - news
+    include_all_sections: false


### PR DESCRIPTION
Closes #151 

When searching for a term, the results found in the 'Projects' section are listed before the results found in the 'News' section.