### PR TITLE
Fix spacing on news headers

### DIFF
--- a/src/hugo/layouts/partials/horizontal-card.html
+++ b/src/hugo/layouts/partials/horizontal-card.html
@@ -20,7 +20,7 @@ SPDX-License-Identifier: BSD-3-Clause
         {{ end }}
         <h3><a href="{{ .Permalink }}" title="{{ .Title }}" class="stretched-link post-title">{{ .Title }}</a></h3>
         {{ with .Params.Date }}
-        <time>{{ .Format "Jan 2, 2006" }}</time>
+        <div class="mb-2"><time>{{ .Format "Jan 2, 2006" }}</time></div>
         {{ end }}
         <p class="card-text">{{ .Summary }}</p>
       </div>

--- a/src/hugo/layouts/shortcodes/project.html
+++ b/src/hugo/layouts/shortcodes/project.html
@@ -120,7 +120,7 @@ SPDX-License-Identifier: BSD-3-Clause
     {{ end }}
         <div class="card-body">
           <h4><a href="{{ .Permalink }}" title="{{ .Title }}" class="stretched-link post-title">{{ .Title }}</a></h4>
-          <time>{{ .Date.Format "Jan 2, 2006" }}</time>
+          <div class="mb-2"><time>{{ .Date.Format "Jan 2, 2006" }}</time></div>
           <p class="card-text">{{ .Summary }}</p>
         </div>
     {{ if .Params.images }}


### PR DESCRIPTION
Closes #155 

## Description 📄

Change the spacing in news cards so the date has equal spacing after the title and before the summary.
