### PR TITLE
Incorporate Inactive, TRLx and Commercial tags

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2026,9 +2026,9 @@ projects:
       email: 'jgarcia@gl-research.com'
     tags:
       - 'Software'
+      - 'Inactive'
     compatibles:
       - 'spec7'
-      - 'Inactive'
   - id: 'distributed-oscilloscope'
     repository: 'https://gitlab.com/ohwr/project/distributed-oscilloscope.git'
     contact:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 CERN (home.cern)

SPDX-License-Identifier: CC-BY-SA-4.0+
-->

Closes #281 <!-- markdownlint-disable-line MD041 -->
Closes #282 

## Description 📄

I have added Inactive, TRLx and Commercial tags in the projects I know. This is just a first pass, and I will do my best to keep these tags up to date in the future. For reference, in order to choose a given TRL for a project, I used the right-most column in the table at https://en.wikipedia.org/wiki/Technology_readiness_level, corresponding to the EU interpretation of TRLs.