### PR TITLE
Include ZU SoM project

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -50,6 +50,7 @@ tags:
   - 'SFP'
   - 'Signal Conditioning'
   - 'SoC'
+  - 'SoM'
   - 'Soft Core'
   - 'Software'
   - 'STM32'
@@ -2316,3 +2317,14 @@ projects:
       - 'STM32'
       - 'TRL7'
       - 'USB'
+  - id: 'zu-som'
+    repository: 'https://gitlab.com/ohwr/project/zu-som.git'
+    contact:
+      name: 'David Nisbet'
+      email: 'David.Nisbet@cern.ch'
+    tags:
+      - 'SoC'
+      - 'SoM'
+      - 'TRL2'
+    compatibles:
+      - 'diot-sb-zu'


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 CERN (home.cern)

SPDX-License-Identifier: CC-BY-SA-4.0+
-->

Closes #338 <!-- markdownlint-disable-line MD041 -->

## Description 📄

<!--
  Provide a brief description of the changes introduced by this pull request.
-->

Include the newly-designed ATS ZU SoM in ohwr.org. Discussed with David Nisbet.

## Additional Notes 📝

<!--
  Any additional information or context that may be helpful for the reviewers.
-->

The design files are not at a version recommended for production yet, but there is already quite some value in them. There is a disclaimer in the wiki next to the link to EDMS.