### PR TITLE
Change contact name in ed project

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2220,8 +2220,8 @@ projects:
   - id: 'ed'
     repository: 'https://gitlab.com/ohwr/project/ed.git'
     contact:
-      name: 'Javier Serrano'
-      email: 'javier.serrano@cern.ch'
+      name: 'Erik van der Bij'
+      email: 'Erik.van.der.Bij@cern.ch'
     tags:
       - 'Documentation'
   - id: 'tdc-core'


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 CERN (home.cern)

SPDX-License-Identifier: CC-BY-SA-4.0+
-->

Closes #353 <!-- markdownlint-disable-line MD041 -->

## Description 📄

The contact name in the Ed project (dealing with best practices for electronics design) should be Erik van der Bij. In the bulk migration, I erroneously put my name it it. This PR fixes that.