### PR TITLE
Changes in CAJU module project

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2305,11 +2305,11 @@ projects:
       - 'Low Noise'
       - 'Signal Conditioning'
       - 'TRL4'
-  - id: 'caju-lnls'
-    repository: 'https://gitlab.com/WilliamArnoniKKWA/caju-lnls.git'
+  - id: 'caju-module'
+    repository: 'https://gitlab.com/ohwr/project/caju-module.git'
     contact:
-      name: 'Patricia Nallin'
-      email: 'patricia.nallin@lnls.br'
+      name: 'João Nilton'
+      email: 'joao@kurokawacontrols.com'
     tags:
       - 'ARM'
       - 'Ethernet'


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 CERN (home.cern)

SPDX-License-Identifier: CC-BY-SA-4.0+
-->

Closes #355 <!-- markdownlint-disable-line MD041 -->

## Description 📄

Change of URL and contact person for CAJU Module project.