### PR TITLE
Add ACCURATE2 Evaluation Board

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2340,7 +2340,7 @@ projects:
     compatibles:
       - 'diot-sb-zu'
       - 'diot-crate-hw'
-- id: 'ACCURATE2-EvalBoard'
+  - id: 'ACCURATE2-EvalBoard'
     repository: 'https://github.com/boukabache/ACCURATE2_EvalBoard.git'
     contact:
       name: 'Hamza Boukabache'


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 CERN (home.cern)

SPDX-License-Identifier: CC-BY-SA-4.0+
-->

This does not close yet issue https://github.com/OHWR/ohwr.org/issues/368 because the rendering of the description for that project is still mangled, but the action needed is on https://github.com/boukabache/ACCURATE2_EvalBoard/blob/master/.ohwr.yaml, not on our side, so I propose to merge this already. 
