### PR TITLE
fix(hugo): allow unicode in projects cards on the home page

### DIFF
--- a/src/hugo/layouts/news/list.json.json
+++ b/src/hugo/layouts/news/list.json.json
@@ -4,7 +4,7 @@
     "title" .Title
     "content" .Plain
     "filter" .Params.project
-    "text" (transform.Plainify .Summary)
+    "text" (transform.Plainify .Summary | htmlUnescape)
     "url" .Permalink
   -}}
   {{- with .Params.images -}}

--- a/src/hugo/layouts/projects/list.json.json
+++ b/src/hugo/layouts/projects/list.json.json
@@ -4,7 +4,7 @@
     "title" .Title
     "id" .Params.id
     "content" .Plain
-    "text" (transform.Plainify .Summary)
+    "text" (transform.Plainify .Summary | htmlUnescape)
     "url" .Permalink
   -}}
   {{- with .Params.tags -}}

--- a/src/hugo/layouts/projects/single.html
+++ b/src/hugo/layouts/projects/single.html
@@ -135,7 +135,7 @@ SPDX-License-Identifier: BSD-3-Clause
             {{ end }}
                 <div class="card-body">
                   <h4><a href="{{ .Permalink }}" title="{{ .Title }}" class="stretched-link post-title">{{ .Title }}</a></h4>
-                  <p class="card-text">{{ transform.Plainify .Summary }}</p>
+                  <p class="card-text">{{ transform.Plainify .Summary | htmlUnescape }}</p>
                 </div>
             {{ if .Params.images }}
               </div>
@@ -156,7 +156,7 @@ SPDX-License-Identifier: BSD-3-Clause
               {{ end }}
                   <div class="card-body">
                     <h4><a href="{{ .Permalink }}" title="{{ .Title }}" class="stretched-link post-title">{{ .Title }}</a></h4>
-                    <p class="card-text">{{ transform.Plainify .Summary }}</p>
+                    <p class="card-text">{{ transform.Plainify .Summary | htmlUnescape }}</p>
                   </div>
               {{ if .Params.images }}
                 </div>
@@ -188,7 +188,7 @@ SPDX-License-Identifier: BSD-3-Clause
                 <div class="card-body">
                   <h4><a href="{{ .Permalink }}" title="{{ .Title }}" class="stretched-link post-title">{{ .Title }}</a></h4>
                   <div class="mb-2"><time>{{ .Date.Format "Jan 2, 2006" }}</time></div>
-                  <p class="card-text">{{ transform.Plainify .Summary }}</p>
+                  <p class="card-text">{{ transform.Plainify .Summary | htmlUnescape }}</p>
                 </div>
             {{ if .Params.images }}
               </div>


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 CERN (home.cern)

SPDX-License-Identifier: CC-BY-SA-4.0+
-->

Closes #375  <!-- markdownlint-disable-line MD041 -->

## Description 📄

In order to correctly display Unicode characters we need to use `htmlUnescape` as seen in the example at https://gohugo.io/functions/transform/htmlunescape/

## Additional Notes 📝

The fix can be tested on https://giacomd.github.io/ohwr.org/ by for example searching for `diot dummy` which now displays correctly:

<img width="555" height="627" alt="image" src="https://github.com/user-attachments/assets/5ce99a0c-10ea-4a75-b513-eacd3c33a042" />

while before:

<img width="555" height="627" alt="image" src="https://github.com/user-attachments/assets/e0306a36-4c92-4d13-8064-3ffd1b9aa25f" />
