### PR TITLE
Add trident-ihp-teststructures project

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2363,3 +2363,11 @@ projects:
       - 'Timing'
       - 'DDS'
       - 'TRL7'
+  - id: 'TRIDENT-IHP-teststructures'
+    repository: 'https://gitlab.cern.ch/trident/trident-ihp-teststructures.git'
+    contact:
+      name: 'Clyde Laforge'
+      email: 'clyde.laforge@cern.ch'
+    tags:
+      - 'Testing'
+      - 'Low Noise'


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 CERN (home.cern)

SPDX-License-Identifier: CC-BY-SA-4.0+
-->

Closes #388 <!-- markdownlint-disable-line MD041 -->

See rendering of new project in the test website at https://javier-serrano-pareja.github.io/ohwr.org/projects/trident-ihp-teststructures/
