### PR TITLE
Add Argos demo board

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -32,6 +32,7 @@ tags:
   - 'High Voltage'
   - 'Hobby'
   - 'Inactive'
+  - 'KiCad'
   - 'Lighting'
   - 'Low Noise'
   - 'Microcontroller'
@@ -55,6 +56,7 @@ tags:
   - 'Soft Core'
   - 'Software'
   - 'STM32'
+  - 'Telemetry'
   - 'TDC'
   - 'Testing'
   - 'Timing'
@@ -2371,3 +2373,11 @@ projects:
     tags:
       - 'Testing'
       - 'Low Noise'
+  - id: 'argos-demo-board'
+    repository: 'https://github.com/CNES/argos-demo-board.git'
+    contact:
+      name: 'Paul Miailhe'
+      email: 'paul.miailhe@cnes.fr'
+    tags:
+      - 'KiCad'
+      - 'Telemetry'


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 CERN (home.cern)

SPDX-License-Identifier: CC-BY-SA-4.0+
-->

Closes #391  <!-- markdownlint-disable-line MD041 -->

## Description 📄

See rendering of new project at https://javier-serrano-pareja.github.io/ohwr.org/projects/argos-demo-board/

@axpaul I added the `KiCad` and `Telemetry` tags, which we did not have so far. I will pass through other projects in the future and add the `KiCad` tag to them as well. I was not sure about adding other tags because I would like to avoid cluttering the search interface. Let me know if any of them is very important to you.