### PR TITLE
Add Quad-Channel Digital Pico ammeter (p4ch-lnls)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2381,3 +2381,12 @@ projects:
     tags:
       - 'KiCad'
       - 'Telemetry'
+  - id: 'P4CH-LNLS'
+    repository: 'https://gitlab.com/ohwr/project/P4CH-LNLS.git'
+    contact:
+      name: 'Patricia Nallin'
+      email: 'patricia.nallin@lnls.br'
+    tags:
+      - 'ADC'
+      - 'Amplifier'
+      - 'Low Noise'


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 CERN (home.cern)

SPDX-License-Identifier: CC-BY-SA-4.0+
-->

Closes #396 <!-- markdownlint-disable-line MD041 -->

